### PR TITLE
Add minimal log support

### DIFF
--- a/ulb.py
+++ b/ulb.py
@@ -270,10 +270,16 @@ dump_map()
 print("... config applied to bpf.")
 
 # Started
-print("\nLoad balancing UDP traffic over {} interface for port(s) {} from :".format(ifnet, ports, ip_ntostr(virtual_server_ip)))
-for real_server_ip in real_server_ips:
-    print ("VIP:{} <=======> Real Server:{}".format(ip_ntostr(virtual_server_ip), ip_ntostr(real_server_ip)))
-
+print("\nLoad balancing UDP traffic over {} interface for port(s) {} :".format(ifnet, ports, ip_ntostr(virtual_server_ip)))
+ip_str_size = 15
+print("{}           {}".format("Virtual Server".rjust(ip_str_size),"Real Server(s)".ljust(ip_str_size)))
+if len(real_server_ips) == 1:
+    print ("{} <───────> {}\n".format(ip_ntostr(virtual_server_ip).rjust(ip_str_size), ip_ntostr(real_server_ips[0]).ljust(ip_str_size)))
+elif len(real_server_ips) > 1:
+    print ("{} <───┬───> {}".format(ip_ntostr(virtual_server_ip).rjust(ip_str_size), ip_ntostr(real_server_ips[0]).ljust(ip_str_size)))
+    for n in range(1,len(real_server_ips)-1):    
+        print ("{}     ├───> {}".format(" " * ip_str_size, ip_ntostr(real_server_ips[n]).ljust(ip_str_size)))
+    print ("{}     └───> {}\n".format(" " * ip_str_size, ip_ntostr(real_server_ips[-1]).ljust(ip_str_size)))
 # Shared structure used for "logs" perf_buffer
 class LogEvent(ct.Structure):
     _fields_ = [


### PR DESCRIPTION
This PR aims to implements #4.
This differs a lot from what it was specify initialy.
Finally there is 6 log levels :

CRITICAL => should never happened,
ERROR => unexpected state,
WARNING => unwanted traffic (invalid packet),
INFO => not supported traffic (fragmented ip, ip option used),
DEBUG => all about NAT,
TRACE => all output we can.

A new CLI option is added : 
```
 -l {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}, --loglevel {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}
                        Use to set logging verbosity.
```

The output looks like this : 
```
Loading real servers from ulb.ini file ...
...real servers loaded : 10.0.0.1, 10.0.0.2, 10.0.0.3.

Compiling & attaching bpf code ...
... compilation and attachement succeed.

Applying config to bpf ...
Add 10.0.0.1 at index 0
Add 10.0.0.2 at index 1
Add 10.0.0.3 at index 2
[1]=10.0.0.2
[2]=10.0.0.3
[0]=10.0.0.1
[10.0.0.2]=10.0.0.2
[10.0.0.1]=10.0.0.1
[10.0.0.3]=10.0.0.3
... config applied to bpf.

Load balancing UDP traffic over lo interface for port(s) [5683] from :
 Virtual Server           Real Server(s) 
      127.0.0.1 <───┬───> 10.0.0.1       
                    ├───> 10.0.0.2       
                    └───> 10.0.0.3 

                                    ┌ 00:00:00:00:00:00/10.0.0.1        Source NAT
    00:00:00:00:00:00/10.41.44.15 <─┘ 00:00:00:00:00:00/127.0.0.1       (NEW ASSOCIATION)
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/10.41.44.15     Unhandled traffic
    00:00:00:00:00:00/10.41.44.15 <─> 00:00:00:00:00:00/127.0.0.1       Not UDP packet
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/127.0.0.1       Not UDP packet
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/127.0.0.1       Not UDP packet
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/127.0.0.1       Not UDP packet
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/127.0.0.1       Not UDP packet
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/127.0.0.1       Not UDP packet
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/127.0.0.1       Not UDP packet
      00:00:00:00:00:00/127.0.0.1 ─┐  00:00:00:00:00:00/127.0.0.1       Destination NAT
                                   └> 00:00:00:00:00:00/10.0.0.2        (NEW ASSOCIATION)
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/10.0.0.2        Unhandled traffic
      00:00:00:00:00:00/127.0.0.1 ─┐  00:00:00:00:00:00/127.0.0.1       Destination NAT
                                   └> 00:00:00:00:00:00/10.0.0.2        (REUSED ASSOCIATION)
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/10.0.0.2        Unhandled traffic
                                    ┌ 00:00:00:00:00:00/10.0.0.1        Source NAT
    00:00:00:00:00:00/10.41.44.15 <─┘ 00:00:00:00:00:00/127.0.0.1       (REUSED ASSOCIATION)
      00:00:00:00:00:00/127.0.0.1 <─> 00:00:00:00:00:00/10.41.44.15     Unhandled traffic
    00:00:00:00:00:00/10.41.44.15 <─> 00:00:00:00:00:00/127.0.0.1       Not UDP packet
    00:00:00:00:00:00/10.41.44.15 <── 00:00:00:00:00:00/10.0.0.2        Not associated real server
    00:00:00:00:00:00/10.41.44.15 <── 00:00:00:00:00:00/10.0.0.2        Not associated real server

Stopping by signal SIGINT(2)...
Detaching bpf code ...
... code detached.
... sbulb stopped.
```

 Of course more could/should? be done : #21