### PR TITLE
Make maximum ports/realservers/associations allowed configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ optional arguments:
   -vs VIRTUAL_SERVER, --virtual_server VIRTUAL_SERVER
                         <Required> Virtual server address (e.g. 10.40.0.1)
   -rs REAL_SERVER [REAL_SERVER ...], --real_server REAL_SERVER [REAL_SERVER ...]
-                        <Required> Real server address(es) (e.g. 10.40.0.1)
+                        <Required> Real server address(es) (e.g. 10.40.0.2 10.40.0.3)
   -cfg CONFIG_FILE, --config_file CONFIG_FILE
                         <Required> a path to a file containing real server address(es). 
                         File will be polled each second for modification and configuration
@@ -31,16 +31,16 @@ optional arguments:
   -p PORT [PORT ...], --port PORT [PORT ...]
                         <Required> UDP port(s) to load balance
   -d {0,1,2,3,4}, --debug {0,1,2,3,4}
-                        Use to set bpf verbosity (0 is minimal)
+                        Use to set bpf verbosity, 0 is minimal. (default: 0)
   -l {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}, --loglevel {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}
-                        Use to set logging verbosity.
+                        Use to set logging verbosity. (default: ERROR)
   -mp MAX_PORTS, --max_ports MAX_PORTS
-                        Set the maximum number of port to load balance.
+                        Set the maximum number of port to load balance. (default: 16)
   -mrs MAX_REALSERVERS, --max_realservers MAX_REALSERVERS
-                        Set the maximum number of real servers.
+                        Set the maximum number of real servers. (default: 32)
   -ma MAX_ASSOCIATIONS, --max_associations MAX_ASSOCIATIONS
-                        Set the maximum number of associations,
-                        meaning the number of foreign peer to support at the same time.
+                        Set the maximum number of associations. (default: 1048576)
+                        This defined the maximum number of foreign peers supported at the same time.
 ```
 Eg : `sudo python3 ulb.py eth0 -vs 10.188.7.99 -rs 10.188.100.163 10.188.100.230  -p 5683 5684
 `

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ An UDP load-balancer prototype using bcc (XDP/Bpf)
 usage: ulb.py [-h] -vs VIRTUAL_SERVER
               (-rs REAL_SERVER [REAL_SERVER ...] | -cfg CONFIG_FILE) -p PORT
               [PORT ...] [-d {0,1,2,3,4}]
+              [-l {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}] [-mp MAX_PORTS]
+              [-mrs MAX_REALSERVERS] [-ma MAX_ASSOCIATIONS]
               ifnet
 
 positional arguments:
@@ -30,6 +32,15 @@ optional arguments:
                         <Required> UDP port(s) to load balance
   -d {0,1,2,3,4}, --debug {0,1,2,3,4}
                         Use to set bpf verbosity (0 is minimal)
+  -l {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}, --loglevel {CRITICAL,ERROR,WARNING,INFO,DEBUG,TRACE}
+                        Use to set logging verbosity.
+  -mp MAX_PORTS, --max_ports MAX_PORTS
+                        Set the maximum number of port to load balance.
+  -mrs MAX_REALSERVERS, --max_realservers MAX_REALSERVERS
+                        Set the maximum number of real servers.
+  -ma MAX_ASSOCIATIONS, --max_associations MAX_ASSOCIATIONS
+                        Set the maximum number of associations,
+                        meaning the number of foreign peer to support at the same time.
 ```
 Eg : `sudo python3 ulb.py eth0 -vs 10.188.7.99 -rs 10.188.100.163 10.188.100.230  -p 5683 5684
 `

--- a/ulb.c
+++ b/ulb.c
@@ -115,12 +115,12 @@ static inline void update_csum(__u64 *csum, __be32 old_addr,__be32 new_addr ) {
 // A map which contains virtual server IP address (__be32)
 BPF_HASH(virtualServer, int, __be32, 1);
 // A map which contains port to redirect
-BPF_HASH(ports, __be16, int, 10); // TODO #5 make the max number of port configurable.
+BPF_HASH(ports, __be16, int, MAX_PORTS);
 // maps which contains real server IP addresses (__be32)
-BPF_HASH(realServersArray, int, __be32, 10); // TODO #5 make the max number of real server configurable.
-BPF_HASH(realServersMap, __be32, __be32, 10); // TODO #5 make the max number of real server configurable.
+BPF_HASH(realServersArray, int, __be32, MAX_REALSERVERS);
+BPF_HASH(realServersMap, __be32, __be32, MAX_REALSERVERS);
 // association tables : link a foreign peer to a real server IP address (__be12)
-BPF_TABLE("lru_hash", struct associationKey, __be32, associationTable, 10000); // TODO #5 make the max number of association configurable.
+BPF_TABLE("lru_hash", struct associationKey, __be32, associationTable, MAX_ASSOCIATIONS);
 // load balancer state
 BPF_HASH(lbState, int, struct state, 1);
 

--- a/ulb.py
+++ b/ulb.py
@@ -67,7 +67,7 @@ parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument("ifnet", help="network interface to load balance (e.g. eth0)")
 parser.add_argument("-vs", "--virtual_server", type=ip_parser, help="<Required> Virtual server address (e.g. 10.40.0.1)", required=True)
 group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument("-rs", "--real_server", type=ip_parser, nargs='+', help="<Required> Real server address(es) (e.g. 10.40.0.1)")
+group.add_argument("-rs", "--real_server", type=ip_parser, nargs='+', help="<Required> Real server address(es) (e.g. 10.40.0.2 10.40.0.3)")
 group.add_argument("-cfg", "--config_file", type=argparse.FileType('r'), help='''<Required> a path to a file containing real server address(es). 
 File will be polled each second for modification and configuration
 updated dynamically. A file content example :
@@ -80,11 +80,11 @@ updated dynamically. A file content example :
 ''')
 parser.add_argument("-p", "--port", type=int, nargs='+', help="<Required> UDP port(s) to load balance", required=True)
 parser.add_argument("-d", "--debug", type=int, choices=[0, 1, 2, 3, 4],
-                    help="Use to set bpf verbosity (0 is minimal)", default=0)
-parser.add_argument("-l", "--loglevel", choices=logLevelNames, help="Use to set logging verbosity.", default="ERROR")
-parser.add_argument("-mp", "--max_ports", type=positive_int, help="Set the maximum number of port to load balance.", default=16)
-parser.add_argument("-mrs", "--max_realservers", type=positive_int, help="Set the maximum number of real servers.", default=32)
-parser.add_argument("-ma", "--max_associations", type=positive_int, help="Set the maximum number of associations,\nmeaning the number of foreign peers supported at the same time.", default=1048576)
+                    help="Use to set bpf verbosity, 0 is minimal. (default: %(default)s)", default=0)
+parser.add_argument("-l", "--loglevel", choices=logLevelNames, help="Use to set logging verbosity. (default: %(default)s)", default="ERROR")
+parser.add_argument("-mp", "--max_ports", type=positive_int, help="Set the maximum number of port to load balance. (default: %(default)s)", default=16)
+parser.add_argument("-mrs", "--max_realservers", type=positive_int, help="Set the maximum number of real servers. (default: %(default)s)", default=32)
+parser.add_argument("-ma", "--max_associations", type=positive_int, help="Set the maximum number of associations. (default: %(default)s)\nThis defined the maximum number of foreign peers supported at the same time.", default=1048576)
 args = parser.parse_args()
 
 # Get configuration from Arguments
@@ -320,6 +320,7 @@ elif len(real_server_ips) > 1:
     for n in range(1,len(real_server_ips)-1):    
         print ("{}     ├───> {}".format(" " * ip_str_size, ip_ntostr(real_server_ips[n]).ljust(ip_str_size)))
     print ("{}     └───> {}\n".format(" " * ip_str_size, ip_ntostr(real_server_ips[-1]).ljust(ip_str_size)))
+
 # Shared structure used for "logs" perf_buffer
 class LogEvent(ct.Structure):
     _fields_ = [


### PR DESCRIPTION
Add new command line options to set bpf max size :
```
  -mp MAX_PORTS, --max_ports MAX_PORTS
                        Set the maximum number of port to load balance.
  -mrs MAX_REALSERVERS, --max_realservers MAX_REALSERVERS
                        Set the maximum number of real servers.
  -ma MAX_ASSOCIATIONS, --max_associations MAX_ASSOCIATIONS
                        Set the maximum number of associations,
                        meaning the number of foreign peer to support at the same time.
```

About the maximum size allowed by bpf for maps, I didn't find so much information about that.
(https://github.com/iovisor/bcc/issues/1471, https://github.com/iovisor/bcc/issues/423#issuecomment-347088216 )
I was able to launch sblub with `MAX_ASSOCIATIONS` set to ~50000000.
More than that will raise :
```
/virtual/main.c:123:1: error: could not open bpf map: Argument list too long
is maps/lru_hash map type enabled in your kernel?
BPF_TABLE("lru_hash", struct associationKey, __be32, associationTable, MAX_ASSOCIATIONS);
```
