### PR TITLE
Handle packet lifetime

### DIFF
--- a/ulb.c
+++ b/ulb.c
@@ -128,6 +128,7 @@ int xdp_prog(struct xdp_md *ctx) {
                 return XDP_PASS;
             case INVALID_IP_SIZE :
             case TOO_SMALL_IP_HEADER:
+            case LIFETIME_EXPIRED:
                 log(WARNING, ctx, res, &logEvent);
                 return XDP_DROP;
             default :
@@ -202,7 +203,7 @@ int xdp_prog(struct xdp_md *ctx) {
             copy_ip_addr(&new_addr, rsIp);
             copy_ip_addr(daddr, rsIp); // use real server IP address as destination
 
-            // TODO #15 we should probably decrement ttl too
+            decrease_packet_lifetime(eth);
         }
     } else {
         // Is it egress traffic ? source ip == a real server IP
@@ -251,7 +252,7 @@ int xdp_prog(struct xdp_md *ctx) {
                 copy_ip_addr(&new_addr,vsIp);
                 copy_ip_addr(saddr,vsIp); // use virtual server IP address as source
 
-                // TODO #15 we should probably decrement ttl too
+                decrease_packet_lifetime(eth);
             }
         } else {
             // neither ingress(destIP=VirtualServerIP) nor egress(sourceIP=RealServerIP) traffic

--- a/ulb.py
+++ b/ulb.py
@@ -190,7 +190,8 @@ class LogCode(Enum):
     INVALID_UDP_SIZE            = "{} <─> {} Invalid size for UDP packet", Direction.UNKNOWN, Kind.UNCHANGED
     NO_VIRTUAL_SERVER           = "{} <─> {} No virtual server configured", Direction.UNKNOWN, Kind.UNCHANGED
     UNHANDLED_TRAFFIC           = "{} <─> {} Unhandled traffic", Direction.UNKNOWN, Kind.UNCHANGED
-    
+    LIFETIME_EXPIRED            = "{} <-> {} TTL or hoplimit expired", Direction.UNKNOWN, Kind.UNCHANGED
+
     INGRESS_NOT_HANDLED_PORT    = "{} ──> {} Unhandled port", Direction.INGRESS, Kind.UNCHANGED
     INGRESS_CANNOT_CREATE_ASSO  = "{} ──> {} Unable to create association", Direction.INGRESS, Kind.UNCHANGED
     INGRESS_CANNOT_CREATE_ASSO2 = "{} ──> {} Unable to create association (MUST not happened", Direction.INGRESS, Kind.UNCHANGED


### PR DESCRIPTION
Decrease packet lifetime (ttl or hop limit) and drop expired packet.
This PR does not add sending ICMP packet when packets is dropped.
(#15)